### PR TITLE
Added support for boolean functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ JSON
 		"0": "No example tags here.",
 		"1": "There is one example tag with name {name: string}.",
 		"n": "There are {count: number} example tags with name {name: string}."
+	},
+	"booleanTexts": {
+		"true": "The bool is true",
+		"false": "The bool is false"
 	}
 }
 ```
@@ -34,6 +38,9 @@ Resulting TypeScript
 			return `There is one example tag with name ${name}.`;
 		}
 		return `There are ${count} example tags with name ${name}.`;
+	},
+	booleanTexts: (bool: boolean) => {
+		return bool ? "The bool is true" : "The bool is false"
 	}
 }
 ```
@@ -48,6 +55,10 @@ getTypeScriptFromString(`{
     "0": "No example tags here.",
     "1": "There is one example tag with name {name: string}.",
     "n": "There are {count: number} example tags with name {name: string}."
+  },
+  "booleanTexts": {
+    "true": "The bool is true",
+    "false": "The bool is false"
   }
 }`);
 ```

--- a/src/Intermediate/IntermediateStructure.ts
+++ b/src/Intermediate/IntermediateStructure.ts
@@ -6,6 +6,7 @@ export enum ValueDescriptionType {
   Array,
   PlaceholderFunction,
   PluralFunction,
+  BooleanFunction,
 }
 
 export interface ValueDescription {
@@ -32,6 +33,7 @@ export enum ArgType {
   String = "string",
   Number = "number",
   Object = "object",
+  Boolean = "boolean",
 }
 
 export interface Arg {
@@ -53,10 +55,21 @@ export interface PluralFormObjectDescription {
   [pluralFormNthKey]: StringPart | string;
 }
 
+export interface BooleanFormObjectDescription {
+  true: StringPart | string;
+  false: StringPart | string;
+}
+
 export interface PluralFunctionValueDescription extends ValueDescription {
   type: ValueDescriptionType.PluralFunction;
   args: Arg[];
   values: PluralFormObjectDescription;
+}
+
+export interface BooleanFunctionValueDescription extends ValueDescription {
+  type: ValueDescriptionType.BooleanFunction;
+  args: Arg[];
+  values: BooleanFormObjectDescription;
 }
 
 const reverseArgType = new Map(Object.keys(ArgType).map((argTypeKey) => [ArgType[argTypeKey], argTypeKey]));
@@ -102,4 +115,10 @@ export function isPluralFunctionValueDescription(
   valueDescription: ValueDescription
 ): valueDescription is PluralFunctionValueDescription {
   return valueDescription.type === ValueDescriptionType.PluralFunction;
+}
+
+export function isBooleanFunctionValueDescription(
+  valueDescription: ValueDescription
+): valueDescription is BooleanFunctionValueDescription {
+  return valueDescription.type === ValueDescriptionType.BooleanFunction;
 }

--- a/src/IntermediateToTypeScript/ExpressionCreation.ts
+++ b/src/IntermediateToTypeScript/ExpressionCreation.ts
@@ -99,12 +99,12 @@ function createPluralFunction(valueDescription: PluralFunctionValueDescription) 
 function createBooleanFunction(valueDescription: BooleanFunctionValueDescription) {
   const parameters = createParameters(valueDescription.args);
 
-  const ifStatement = createBooleanIfElse(
+  const conditionalReturn = createBooleanConditionalReturn(
     valueDescription.values[booleanFormTrueKey],
     valueDescription.values[booleanFormFalseKey]
   );
 
-  const block = factory.createBlock([ifStatement], false);
+  const block = factory.createBlock([conditionalReturn], false);
 
   return factory.createArrowFunction(undefined, undefined, parameters, undefined, undefined, block);
 }
@@ -147,16 +147,10 @@ function createValueString(stringPart: string | StringPart) {
   return typeof stringPart === "string" ? factory.createStringLiteral(stringPart) : createTemplate(stringPart);
 }
 
-function createBooleanIfElse(trueValue: string | StringPart, falseValue: string | StringPart) {
-  const condition = factory.createBinaryExpression(
-    factory.createIdentifier("bool"),
-    SyntaxKind.EqualsEqualsEqualsToken,
-    factory.createTrue()
-  );
-
+function createBooleanConditionalReturn(trueValue: string | StringPart, falseValue: string | StringPart) {
   return factory.createReturnStatement(
     factory.createConditionalExpression(
-      condition,
+      factory.createIdentifier("bool"),
       undefined,
       createValueString(trueValue),
       undefined,

--- a/src/IntermediateToTypeScript/ExpressionCreation.ts
+++ b/src/IntermediateToTypeScript/ExpressionCreation.ts
@@ -140,20 +140,27 @@ function createPluralIfBlock(valueKey: string, value: string | StringPart) {
 }
 
 function createPluralValueReturn(stringPart: string | StringPart) {
-  return factory.createReturnStatement(
-    typeof stringPart === "string" ? factory.createStringLiteral(stringPart) : createTemplate(stringPart)
-  );
+  return factory.createReturnStatement(createValueString(stringPart));
+}
+
+function createValueString(stringPart: string | StringPart) {
+  return typeof stringPart === "string" ? factory.createStringLiteral(stringPart) : createTemplate(stringPart);
 }
 
 function createBooleanIfElse(trueValue: string | StringPart, falseValue: string | StringPart) {
   const condition = factory.createBinaryExpression(
-    factory.createIdentifier("boolean"),
+    factory.createIdentifier("bool"),
     SyntaxKind.EqualsEqualsEqualsToken,
     factory.createTrue()
   );
 
-  const ifBody = factory.createBlock([createPluralValueReturn(trueValue)], false);
-  const elseBody = factory.createBlock([createPluralValueReturn(falseValue)], false);
-
-  return factory.createIfStatement(condition, ifBody, elseBody);
+  return factory.createReturnStatement(
+    factory.createConditionalExpression(
+      condition,
+      undefined,
+      createValueString(trueValue),
+      undefined,
+      createValueString(falseValue)
+    )
+  );
 }

--- a/src/IntermediateToTypeScript/ExpressionCreation.ts
+++ b/src/IntermediateToTypeScript/ExpressionCreation.ts
@@ -15,7 +15,6 @@ import {
   PluralFormObjectDescription,
   isBooleanFunctionValueDescription,
   BooleanFunctionValueDescription,
-  BooleanFormObjectDescription,
 } from "../Intermediate/IntermediateStructure";
 import { booleanFormFalseKey, booleanFormTrueKey, pluralFormNthKey } from "../JsonToIntermediate/JsonStructure";
 import createParameters from "./ParameterCreation";
@@ -100,9 +99,12 @@ function createPluralFunction(valueDescription: PluralFunctionValueDescription) 
 function createBooleanFunction(valueDescription: BooleanFunctionValueDescription) {
   const parameters = createParameters(valueDescription.args);
 
-  const statements = createBooleanStatements(valueDescription.values);
+  const ifStatement = createBooleanIfElse(
+    valueDescription.values[booleanFormTrueKey],
+    valueDescription.values[booleanFormFalseKey]
+  );
 
-  const block = factory.createBlock(statements, false);
+  const block = factory.createBlock([ifStatement], false);
 
   return factory.createArrowFunction(undefined, undefined, parameters, undefined, undefined, block);
 }
@@ -125,13 +127,6 @@ function createPluralStatements(values: PluralFormObjectDescription) {
   return statements;
 }
 
-function createBooleanStatements(values: BooleanFormObjectDescription) {
-  const trueValue = values[booleanFormTrueKey];
-  const falseValue = values[booleanFormFalseKey];
-
-  return [createBooleanValue(trueValue, falseValue)];
-}
-
 function createPluralIfBlock(valueKey: string, value: string | StringPart) {
   const condition = factory.createBinaryExpression(
     factory.createIdentifier("count"),
@@ -150,9 +145,9 @@ function createPluralValueReturn(stringPart: string | StringPart) {
   );
 }
 
-function createBooleanValue(trueValue: string | StringPart, falseValue: string | StringPart) {
+function createBooleanIfElse(trueValue: string | StringPart, falseValue: string | StringPart) {
   const condition = factory.createBinaryExpression(
-    factory.createIdentifier("bool"),
+    factory.createIdentifier("boolean"),
     SyntaxKind.EqualsEqualsEqualsToken,
     factory.createTrue()
   );

--- a/src/IntermediateToTypeScript/ParameterCreation.ts
+++ b/src/IntermediateToTypeScript/ParameterCreation.ts
@@ -17,5 +17,7 @@ function mapType(argType: ArgType) {
       return SyntaxKind.NumberKeyword;
     case ArgType.Object:
       return SyntaxKind.ObjectKeyword;
+    case ArgType.Boolean:
+      return SyntaxKind.BooleanKeyword;
   }
 }

--- a/src/JsonToIntermediate/JsonConversion.ts
+++ b/src/JsonToIntermediate/JsonConversion.ts
@@ -72,7 +72,8 @@ function getPluralFunctionValues(nthValue: string) {
 }
 
 function convertBooleanFormObject(obj: BooleanFormObject): BooleanFunctionValueDescription {
-  const argSet = createArgSet([]);
+  const fixedBoolArg = { name: "boolean", type: ArgType.Boolean };
+  const argSet = createArgSet([fixedBoolArg]);
   const values = {} as BooleanFormObjectDescription;
 
   const keys = Object.keys(obj);

--- a/src/JsonToIntermediate/JsonConversion.ts
+++ b/src/JsonToIntermediate/JsonConversion.ts
@@ -12,12 +12,27 @@ import {
   PrimitiveValueDescription,
   isPrimitiveStringValueDescription,
   ArrayValueDescription,
+  BooleanFunctionValueDescription,
+  BooleanFormObjectDescription,
 } from "../Intermediate/IntermediateStructure";
 import { placeholderRegex, getAllMatches } from "./RegexUtils";
-import { PluralFormObject, PrimitiveJsonType, pluralFormNthKey } from "./JsonStructure";
+import {
+  BooleanFormObject,
+  PluralFormObject,
+  PrimitiveJsonType,
+  booleanFormFalseKey,
+  booleanFormTrueKey,
+  pluralFormNthKey,
+} from "./JsonStructure";
 
-export default function convertObject(value: object): ObjectValueDescription | PluralFunctionValueDescription {
-  return isPluralFormObject(value) ? convertPluralFormObject(value) : convertSimpleObject(value);
+export default function convertObject(
+  value: object
+): ObjectValueDescription | PluralFunctionValueDescription | BooleanFunctionValueDescription {
+  return isPluralFormObject(value)
+    ? convertPluralFormObject(value)
+    : isBooleanFormObject(value)
+    ? convertBooleanFormObject(value)
+    : convertSimpleObject(value);
 }
 
 function convertPluralFormObject(obj: PluralFormObject): PluralFunctionValueDescription {
@@ -54,6 +69,33 @@ function getPluralFunctionValues(nthValue: string) {
   return isPrimitiveValueDescription(nthValueDescription)
     ? { n: nthValueDescription.value }
     : { n: nthValueDescription.stringParts };
+}
+
+function convertBooleanFormObject(obj: BooleanFormObject): BooleanFunctionValueDescription {
+  const argSet = createArgSet([]);
+  const values = {} as BooleanFormObjectDescription;
+
+  const keys = Object.keys(obj);
+  for (const key of keys) {
+    const valueDescription = convertString(obj[key]);
+
+    if (isPrimitiveStringValueDescription(valueDescription)) {
+      values[key] = valueDescription.value;
+      continue;
+    }
+
+    for (const arg of valueDescription.args) {
+      argSet.add(arg);
+    }
+
+    values[key] = valueDescription.stringParts;
+  }
+
+  return {
+    type: ValueDescriptionType.BooleanFunction,
+    args: argSet.args,
+    values,
+  };
 }
 
 function convertSimpleObject(obj: object): ObjectValueDescription {
@@ -145,6 +187,14 @@ function isPluralFormObject(obj: { [pluralFormNthKey]?: string }): obj is Plural
   return (
     obj[pluralFormNthKey] !== undefined &&
     Object.keys(obj).every((key) => (key === pluralFormNthKey || /^\d+$/.test(key)) && typeof obj[key] === "string")
+  );
+}
+
+function isBooleanFormObject(obj: { stringParts?: string }): obj is BooleanFormObject {
+  return (
+    obj[booleanFormTrueKey] !== undefined &&
+    obj[booleanFormFalseKey] !== undefined &&
+    Object.keys(obj).every((key) => (key === booleanFormTrueKey || booleanFormFalseKey) && typeof obj[key] === "string")
   );
 }
 

--- a/src/JsonToIntermediate/JsonConversion.ts
+++ b/src/JsonToIntermediate/JsonConversion.ts
@@ -72,7 +72,7 @@ function getPluralFunctionValues(nthValue: string) {
 }
 
 function convertBooleanFormObject(obj: BooleanFormObject): BooleanFunctionValueDescription {
-  const fixedBoolArg = { name: "boolean", type: ArgType.Boolean };
+  const fixedBoolArg = { name: "bool", type: ArgType.Boolean };
   const argSet = createArgSet([fixedBoolArg]);
   const values = {} as BooleanFormObjectDescription;
 

--- a/src/JsonToIntermediate/JsonStructure.ts
+++ b/src/JsonToIntermediate/JsonStructure.ts
@@ -2,7 +2,15 @@ export type PrimitiveJsonType = boolean | number | string;
 
 export const pluralFormNthKey = "n";
 
+export const booleanFormTrueKey = "true";
+export const booleanFormFalseKey = "false";
+
 export interface PluralFormObject {
   [count: number]: string;
   [pluralFormNthKey]: string;
+}
+
+export interface BooleanFormObject {
+  type: string;
+  stringParts: string;
 }

--- a/src/JsonToIntermediate/JsonStructure.ts
+++ b/src/JsonToIntermediate/JsonStructure.ts
@@ -11,6 +11,6 @@ export interface PluralFormObject {
 }
 
 export interface BooleanFormObject {
-  type: string;
+  boolean: boolean;
   stringParts: string;
 }

--- a/tests/IntermediateToTypeScript/ExpressionCreation.test.ts
+++ b/tests/IntermediateToTypeScript/ExpressionCreation.test.ts
@@ -21,6 +21,8 @@ import {
   isBinaryExpression,
   BinaryExpression,
   NumericLiteral,
+  isConditionalExpression,
+  ConditionalExpression,
 } from "typescript";
 import createExpression from "../../src/IntermediateToTypeScript/ExpressionCreation";
 import {
@@ -412,69 +414,30 @@ describe("TypeScriptCreation", () => {
         expect(isBlock(result.body)).toBe(true);
       });
 
-      it("returns arrow function with block containing if else block returning value of true/false", () => {
+      it("returns arrow function with block containing conditional return", () => {
         // Arrange
 
         // Act
         const result = (createExpression(testBooleanFunctionValueDescription) as ArrowFunction).body as Block;
 
         // Assert
-        expect(isIfStatement(result.statements[0])).toBe(true);
-        expect(isBlock((result.statements[0] as IfStatement).thenStatement)).toBe(true);
-        expect((result.statements[0] as IfStatement).elseStatement !== undefined).toBe(true);
-        expect(isBlock((result.statements[0] as IfStatement).elseStatement!)).toBe(true);
-
-        expect(isReturnStatement(((result.statements[0] as IfStatement).thenStatement as Block).statements[0])).toBe(
-          true
+        expect(isReturnStatement(result.statements[0])).toBe(true);
+        expect(isConditionalExpression((result.statements[0] as ReturnStatement).expression!)).toBe(true);
+        expect(((result.statements[0] as ReturnStatement).expression as ConditionalExpression).condition.kind).toBe(
+          SyntaxKind.Identifier
         );
         expect(
-          isStringLiteral(
-            (((result.statements[0] as IfStatement).thenStatement as Block).statements[0] as ReturnStatement)
-              .expression!
-          )
-        ).toBe(true);
-        expect(
-          (
-            (((result.statements[0] as IfStatement).thenStatement as Block).statements[0] as ReturnStatement)
-              .expression as StringLiteral
-          ).text
-        ).toBe(testBooleanFunctionValueDescription.values["true"]);
-
-        expect(isReturnStatement(((result.statements[0] as IfStatement).elseStatement as Block).statements[0])).toBe(
-          true
-        );
-        expect(
-          isStringLiteral(
-            (((result.statements[0] as IfStatement).elseStatement as Block).statements[0] as ReturnStatement)
-              .expression!
-          )
-        ).toBe(true);
-        expect(
-          (
-            (((result.statements[0] as IfStatement).elseStatement as Block).statements[0] as ReturnStatement)
-              .expression as StringLiteral
-          ).text
-        ).toBe(testBooleanFunctionValueDescription.values["false"]);
-      });
-
-      it("returns arrow function with block containing if block checking for true", () => {
-        // Arrange
-
-        // Act
-        const result = (createExpression(testBooleanFunctionValueDescription) as ArrowFunction).body as Block;
-
-        // Assert
-        expect(isIfStatement(result.statements[0])).toBe(true);
-        expect(isBinaryExpression((result.statements[0] as IfStatement).expression)).toBe(true);
-        expect(
-          (((result.statements[0] as IfStatement).expression as BinaryExpression).left as Identifier).escapedText
+          (((result.statements[0] as ReturnStatement).expression as ConditionalExpression).condition as Identifier)
+            .escapedText
         ).toBe("bool");
-        expect(((result.statements[0] as IfStatement).expression as BinaryExpression).right.kind).toBe(
-          SyntaxKind.TrueKeyword
+        expect(
+          (((result.statements[0] as ReturnStatement).expression as ConditionalExpression).whenTrue as StringLiteral)
+            .text
+        ).toBe(testBooleanFunctionValueDescription.values.true);
+        expect(((result.statements[0] as ReturnStatement).expression as ConditionalExpression).whenFalse).toBe(
+          testTemplateExpression
         );
-        expect(((result.statements[0] as IfStatement).expression as BinaryExpression).operatorToken.kind).toBe(
-          SyntaxKind.EqualsEqualsEqualsToken
-        );
+        expect(createTemplate).toHaveBeenCalledWith(testBooleanFunctionValueDescription.values.false);
       });
     });
   });

--- a/tests/IntermediateToTypeScript/ExpressionCreation.test.ts
+++ b/tests/IntermediateToTypeScript/ExpressionCreation.test.ts
@@ -468,7 +468,7 @@ describe("TypeScriptCreation", () => {
         expect(isBinaryExpression((result.statements[0] as IfStatement).expression)).toBe(true);
         expect(
           (((result.statements[0] as IfStatement).expression as BinaryExpression).left as Identifier).escapedText
-        ).toBe("boolean");
+        ).toBe("bool");
         expect(((result.statements[0] as IfStatement).expression as BinaryExpression).right.kind).toBe(
           SyntaxKind.TrueKeyword
         );

--- a/tests/JsonToIntermediate/JsonConversion.test.ts
+++ b/tests/JsonToIntermediate/JsonConversion.test.ts
@@ -9,6 +9,7 @@ import {
   isArrayValueDescription,
   isPrimitiveValueDescription,
   ValueDescriptionType,
+  isBooleanFunctionValueDescription,
 } from "../../src/Intermediate/IntermediateStructure";
 
 describe("JsonConversion", () => {
@@ -314,6 +315,74 @@ describe("JsonConversion", () => {
           {
             name: "count",
             type: "number",
+          },
+          {
+            name: "somePlaceholder",
+            type: "object",
+          },
+          {
+            name: "anotherPlaceholder",
+            type: "string",
+          },
+        ]);
+      });
+
+      it("converts boolean form objects to BooleanFunctionValueDescription", () => {
+        // Arrange
+        const testPropertyName = "myObjectProp";
+        const testPropertyValue = {
+          true: "test is true",
+          false: "test is false",
+        };
+        const testJsonObject = {
+          [testPropertyName]: testPropertyValue,
+        };
+
+        // Act
+        const result = convertObject(testJsonObject);
+
+        // Assert
+        const objectValueDescription = getAs(isObjectValueDescription, result);
+        const booleanFunctionValueDescription = getAs(
+          isBooleanFunctionValueDescription,
+          objectValueDescription.propertyDescriptions.get(testPropertyName)
+        );
+        expect(booleanFunctionValueDescription.args).toEqual([
+          {
+            name: "boolean",
+            type: "boolean",
+          },
+        ]);
+        expect(booleanFunctionValueDescription.values).toEqual({
+          true: "test is true",
+          false: "test is false",
+        });
+      });
+
+      it("adds all args of the boolean form objects property values", () => {
+        // Arrange
+        const testPropertyName = "myObjectProp";
+        const testPropertyValue = {
+          true: "{ somePlaceholder: object } is true",
+          false: "{ anotherPlaceholder: string } is false",
+        };
+        const testJsonObject = {
+          [testPropertyName]: testPropertyValue,
+        };
+
+        // Act
+        const result = convertObject(testJsonObject);
+
+        // Assert
+        const objectValueDescription = getAs(isObjectValueDescription, result);
+        const booleanFunctionValueDescription = getAs(
+          isBooleanFunctionValueDescription,
+          objectValueDescription.propertyDescriptions.get(testPropertyName)
+        );
+        expect(booleanFunctionValueDescription.args).toEqual([
+          {
+            name: "boolean",
+            type: "boolean",
           },
           {
             name: "somePlaceholder",

--- a/tests/JsonToIntermediate/JsonConversion.test.ts
+++ b/tests/JsonToIntermediate/JsonConversion.test.ts
@@ -349,7 +349,7 @@ describe("JsonConversion", () => {
         );
         expect(booleanFunctionValueDescription.args).toEqual([
           {
-            name: "boolean",
+            name: "bool",
             type: "boolean",
           },
         ]);
@@ -381,7 +381,7 @@ describe("JsonConversion", () => {
         );
         expect(booleanFunctionValueDescription.args).toEqual([
           {
-            name: "boolean",
+            name: "bool",
             type: "boolean",
           },
           {


### PR DESCRIPTION
With this PR,  i18n-json-to-ts supports boolean functions.
When the json is written as follows
`"myCoolBooleanString":{
      "true": "The string is true",
      "false": "The string is false"
    },`
then it generates following ts code
`myCoolBooleanString: (bool: boolean) => { return bool ? "The string is true" : "The string is false"; }`